### PR TITLE
Update Typedoc-Webpack-Plugin to properly use paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The default options that are set by the plugin are:
 
 ```
 {
-	out: '/docs',
+	out: './docs',
 	module: 'commonjs',
 	target: 'es5',
 	exclude: '**/node_modules/**/*.*',
@@ -45,7 +45,7 @@ plugins: [
 ]
 ```
 
-The output path of the docs is relative to the output path specified in the webpack configuration. For example:
+You can pass either absolute or relative paths as the configuration parameter out. The default output path of the docs is relative to the output path specified in the webpack configuration. For example:
 
 ```
 output: {
@@ -53,4 +53,6 @@ output: {
 }
 ```
 
-With the default configuration, the above example would produce the docs under the following path: ./target/docs
+With the default configuration, the above example would produce the docs under the following path: ./target/docs.
+
+Relative paths can also be specified as the out parameter. For example out: '../docs', would produce the docs under the following path: ./docs.

--- a/index.js
+++ b/index.js
@@ -26,13 +26,14 @@
 
 var typedoc = require('typedoc');
 var clone = require('lodash.clone');
-var merge = require('lodash.merge')
+var merge = require('lodash.merge');
+var path = require('path');
 
 function TypedocWebpackPlugin(options) {
 	this.startTime = Date.now();
   	this.prevTimestamps = {};
   	this.defaultTypedocOptions = {
-  		out: '/docs',
+  		out: './docs',
   		module: 'commonjs',
 		target: 'es5',
 		exclude: '**/node_modules/**/*.*',
@@ -71,11 +72,15 @@ TypedocWebpackPlugin.prototype.apply = function(compiler) {
 		// if typescript files have been changed or we cannot determine what files have been changed run typedoc build
 		if(tsFileEdited || changedFiles.length === 0) 
 		{
-			// if output path is specified in webpack config,
+			// If an absolute path set in self.typeDocOptions.out, use that
+			// else if the output path is specified in webpack config and out is relative
 			// output typedocs relative to that path
 			var typedocOptions = clone(self.typeDocOptions);
-			if(compiler.options.output && compiler.options.output.path) {
-				typedocOptions.out = compiler.options.output.path + self.typeDocOptions.out;
+
+			if(path.isAbsolute(self.typeDocOptions.out)){
+				typedocOptions.out = self.typeDocOptions.out;
+			}else if(compiler.options.output && compiler.options.output.path) {
+				typedocOptions.out = path.join(compiler.options.output.path, self.typeDocOptions.out);
 			}
 
 			var typedocApp = new typedoc.Application(typedocOptions);
@@ -98,6 +103,6 @@ TypedocWebpackPlugin.prototype.apply = function(compiler) {
 	compiler.plugin('done', function (stats) {
 		console.log('Typedoc finished generating');
 	});
-}
+};
 
 module.exports = TypedocWebpackPlugin;


### PR DESCRIPTION
RE: https://github.com/Microsoft/Typedoc-Webpack-Plugin/issues/9

I made this PR to fix the behaviour of the output path for the generated typedoc files. The PR leverages node's path module.

Currently if you specify something like '../docs' in the out param it will output to the build directory but in a garbled directory structure due to the use of simple + concatenation. Absolute paths also do not work.

In this PR the default has been updated to './docs' this will produce the exact same output as the existing plugin. However, now you can specify relative paths (such as ''../docs' to go down a directory) or an absolute path. 

I also added two missing semicolons to the existing source code and updated the readme.

The version number has not been updated in package.json.
