### PR TITLE
Fix typedoc dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "lodash.merge": "^4.6.0"
   },
   "peerDependencies": {
-    "typedoc": "^0.5.0"
+    "typedoc": ">= 0.5.0"
   }
 }


### PR DESCRIPTION
Addresses issue #19 

This should work with Typedoc version 0.6.0 without issue.