### PR TITLE
Update typedoc's peerDependency to 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "lodash.merge": "^4.6.0"
   },
   "peerDependencies": {
-    "typedoc": ">= 0.5.0"
+    "typedoc": ">= 0.13.0"
   }
 }


### PR DESCRIPTION
`typedoc`'s dependency is a bit outdated. This change updates it to the latest version available.